### PR TITLE
Data folder now should be created / searched for under the execution path of the program as intended

### DIFF
--- a/internal/csvParser/mostCommonPort.go
+++ b/internal/csvParser/mostCommonPort.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -50,8 +51,8 @@ func NewMostCommonPort(service string, number uint16, proto string, freq float64
 	}
 }
 
-func NewMostCommonPorts() *MostCommonPorts {
-	csvFile, _ := os.Open("data/port_open_freq.csv")
+func NewMostCommonPorts(dataDir string) *MostCommonPorts {
+	csvFile, _ := os.Open(path.Join(dataDir, "port_open_freq.csv"))
 	reader := csv.NewReader(bufio.NewReader(csvFile))
 
 	var commonPorts MostCommonPorts

--- a/internal/xmlParser/xmlParser.go
+++ b/internal/xmlParser/xmlParser.go
@@ -24,10 +24,11 @@ import (
 	"encoding/xml"
 	"io/ioutil"
 	"os"
+	"path"
 )
 
-func NewPortRegistry() (*PortRegistry, error) {
-	xmlFile, err := os.Open("data/port-numbers.xml")
+func NewPortRegistry(dataFolder string) (*PortRegistry, error) {
+	xmlFile, err := os.Open(path.Join(dataFolder, "port-numbers.xml"))
 	if err != nil {
 		return nil, err
 	}

--- a/netUtil/port.go
+++ b/netUtil/port.go
@@ -41,9 +41,9 @@ func NewPort(portNo uint16, proto string, service string, desc string) *Port {
 	return &Port{PortNo: portNo, Protocol: proto, Service: service, Description: desc}
 }
 
-func ParsePortString(portArgs string, proto string) Ports {
+func ParsePortString(portArgs string, proto string, dataFolder string) Ports {
 	var tgtPorts Ports
-	portRegistry, err := xmlParser.NewPortRegistry()
+	portRegistry, err := xmlParser.NewPortRegistry(dataFolder)
 	if err == nil {
 		ports := strings.Split(portArgs, ",")
 		for _, portArg := range ports {


### PR DESCRIPTION
- The data folder now should be created / searched for under the execution path of the program as intended, and not in the current working directory of the user. This closes #1. 
- _Scan results for now still will be saved in the current working directory if the appropriate flag is passed._